### PR TITLE
Add table of contents to the top of the API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,7 @@
 Registry API
 ************
 
+.. contents::
 
 Auth
 ====


### PR DESCRIPTION
This adds the simpler `.. contents::` table of contents to the REST API docs.
