### PR TITLE
Add note about content api requirement of client and session token.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,6 +131,13 @@ If the API call fails, the resultant object will be of the form
 Content
 =======
 
+All content API endpoints require the client to have authenticated themselves. 
+For each request the client is required to send along the client name and 
+session token as ``client_name`` and ``session_token`` respectively. If the 
+parameters are not present or if the session is invalid or has timed out, 
+a 401 HTTP response is sent back.
+
+
 GET /
 ^^^^^
 


### PR DESCRIPTION
This PR adds a note in the content API section about the fact that all APIs require the `client_name` and `session_token` parameters to be sent along with other parameters for each request.
