### PR TITLE
Remove client_name as a parameter for content api.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,6 +131,13 @@ If the API call fails, the resultant object will be of the form
 Content
 =======
 
+All content API endpoints require the client to have authenticated themselves 
+and to send along the session token for each request as ``session_token`` 
+parameter. If the token is not present or if the session is invalid or has 
+timed-out, a `401` HTTP response is sent back and the client has to 
+re-authenticate before proceeding further.
+
+
 GET /
 ^^^^^
 

--- a/registry/auth/sessions.py
+++ b/registry/auth/sessions.py
@@ -166,14 +166,11 @@ class SessionManager(object):
             'duration': duration,
             'initiated': time.time(),
         })
-        self._store_session(client, session)
+        self._store_session(session)
         return session
 
-    def verify_session(self, client_name, session_token):
-        client = self.client_manager.get_client(client_name)
-        if not client:
-            return False, 'No such client'
-        session = self._load_session(client_name, session_token)
+    def verify_session(self, session_token):
+        session = self._load_session(session_token)
         if not session:
             return False, 'No session found'
         if not session.is_valid():
@@ -186,15 +183,15 @@ class SessionManager(object):
         duration = min(requested_duration, self.SESSION_MAX_DURATION)
         return duration
 
-    def invalidate_session(self, client_name, session_token):
-        self.sessions.pop((client_name, session_token), None)
+    def invalidate_session(self, session_token):
+        self.sessions.pop(session_token, None)
 
-    def _store_session(self, client, session):
+    def _store_session(self, session):
         token = session['token']
-        self.sessions[(client['name'], token)] = session
+        self.sessions[token] = session
 
-    def _load_session(self, client_name, token):
-        return self.sessions.get((client_name, token))
+    def _load_session(self, token):
+        return self.sessions.get(token)
 
     def generate_session_token(self):
         return uuid.uuid4().hex
@@ -215,7 +212,7 @@ class SessionManager(object):
 
         for key, session in self.sessions.items():
             if not session.is_valid():
-                self.invalidate_session(*key)
+                self.invalidate_session(key)
                 count += 1
         return count
 

--- a/registry/auth/sessions.py
+++ b/registry/auth/sessions.py
@@ -170,6 +170,12 @@ class SessionManager(object):
         return session
 
     def verify_session(self, session_token):
+        """
+        Returns a tuple, with the first member as `True` and the second member
+        as the session if a valid session exists for `session_token`. Else a
+        tuple with the first member as `False` and the second member as the
+        failure reason is returned.
+        """
         session = self._load_session(session_token)
         if not session:
             return False, 'No session found'
@@ -184,6 +190,7 @@ class SessionManager(object):
         return duration
 
     def invalidate_session(self, session_token):
+        """ Invalidates the session with the token `session_token`. """
         self.sessions.pop(session_token, None)
 
     def _store_session(self, session):

--- a/registry/auth/utils.py
+++ b/registry/auth/utils.py
@@ -26,10 +26,9 @@ def get_session_manager():
 def check_auth(func):
     @functools.wraps(func)
     def decorator(*args, **kwargs):
-        name = request.params.get('client_name')
         token = request.params.get('session_token')
         sessions = get_session_manager()
-        verified, session = sessions.verify_session(name, token)
+        verified, session = sessions.verify_session(token)
         if verified:
             request.session = session
             return func(*args, **kwargs)


### PR DESCRIPTION
This PR drops `client_name` as a one of the authentication parameters required for content API. `client_name` did not have any benefits which the other parameter `session_token` does not provide.
